### PR TITLE
Fixed a material error that occurred when bloom is turned on

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -26,6 +26,7 @@ namespace NoteCutGuide
 		public virtual Color Right { get; set; } = new Color(1f, 1f, 1f, 1f);
 		public virtual bool Ignore { get; set; } = true;
 		public virtual bool Bloom { get; set; } = false;
+		public virtual float Brightness { get; set; } = 1.0f;
 		public virtual bool Rainbow { get; set; } = false;
 
 		/// <summary>

--- a/HarmonyPatches/GuideInitializer.cs
+++ b/HarmonyPatches/GuideInitializer.cs
@@ -451,24 +451,21 @@ namespace NoteCutGuide.HarmonyPatches {
 			// Fake bloom
 			var renderer = guide.GetComponent<MeshRenderer>();
 			if(Config.Instance.Bloom) {
-				renderer.material.shader = Shader.Find("Unlit");
+				renderer.material.shader = Shader.Find("UI/Default");
 			} else {
 				renderer.material.shader = Plugin.DefaultShader;
 			}
 
-			// Fake bloom is not compatible with any of this
-			if(!Config.Instance.Bloom) {
-				if(Config.Instance.Rainbow) {
-					renderer.material.color = Helper.Rainbow(); // Random colors
-				} else if(Config.Instance.Color) {
-					if(noteController.noteData.colorType == ColorType.ColorA) { // Custom colors
-						renderer.material.color = Config.Instance.Left;
-					} else if(noteController.noteData.colorType == ColorType.ColorB) {
-						renderer.material.color = Config.Instance.Right;
-					}
-				} else {
-					renderer.material.color = ColorNoteVisuals_noteColor(ref __instance); // Default colors
+			if(Config.Instance.Rainbow) {
+				renderer.material.color = Helper.Rainbow(); // Random colors
+			} else if(Config.Instance.Color) {
+				if(noteController.noteData.colorType == ColorType.ColorA) { // Custom colors
+					renderer.material.color = Config.Instance.Left;
+				} else if(noteController.noteData.colorType == ColorType.ColorB) {
+					renderer.material.color = Config.Instance.Right;
 				}
+			} else {
+				renderer.material.color = ColorNoteVisuals_noteColor(ref __instance); // Default colors
 			}
 
 			// Activate/Disable

--- a/HarmonyPatches/GuideInitializer.cs
+++ b/HarmonyPatches/GuideInitializer.cs
@@ -460,12 +460,12 @@ namespace NoteCutGuide.HarmonyPatches {
 				renderer.material.color = Helper.Rainbow(); // Random colors
 			} else if(Config.Instance.Color) {
 				if(noteController.noteData.colorType == ColorType.ColorA) { // Custom colors
-					renderer.material.color = Config.Instance.Left;
+					renderer.material.color = ColorExtensions.ColorWithAlpha(Config.Instance.Left, Config.Instance.Brightness);
 				} else if(noteController.noteData.colorType == ColorType.ColorB) {
-					renderer.material.color = Config.Instance.Right;
+					renderer.material.color = ColorExtensions.ColorWithAlpha(Config.Instance.Right, Config.Instance.Brightness);
 				}
 			} else {
-				renderer.material.color = ColorNoteVisuals_noteColor(ref __instance); // Default colors
+				renderer.material.color = ColorExtensions.ColorWithAlpha(ColorNoteVisuals_noteColor(ref __instance), Config.Instance.Brightness); // Default colors
 			}
 
 			// Activate/Disable

--- a/Views/settings.bsml
+++ b/Views/settings.bsml
@@ -40,9 +40,9 @@
 	</horizontal>
 	<checkbox-setting apply-on-change="true" value="Ignore" text="Ignore Dot Note"/>
 	<checkbox-setting apply-on-change="true" value="Bloom" text="Bloom"
-				  hover-hint="Not compatible with Custom Color/Rainbow"
+				  hover-hint="Compatible with Custom Color/Rainbow"
 					/>
 	<checkbox-setting apply-on-change="true" value="Rainbow" text="Rainbow"
-				  hover-hint="Not compatible with Custom Color/Bloom"
+				  hover-hint="Not compatible with Custom Color"
 					/>
 </settings-container>

--- a/Views/settings.bsml
+++ b/Views/settings.bsml
@@ -42,6 +42,8 @@
 	<checkbox-setting apply-on-change="true" value="Bloom" text="Bloom"
 				  hover-hint="Compatible with Custom Color/Rainbow"
 					/>
+	<slider-setting apply-on-change="true" value="Brightness" text="Brightness"
+					min="0" max="1" increment="0.05"/>
 	<checkbox-setting apply-on-change="true" value="Rainbow" text="Rainbow"
 				  hover-hint="Not compatible with Custom Color"
 					/>


### PR DESCRIPTION
Fixed a material error that occurred when bloom is turned on.
It makes bloom compatible with default color, cusom color and rainbow.
If bloom is on, the colors seem to be a little too bright.
So I added a brightness adjustment function.
This function works even when bloom is off, but you can rewrite it so that it does not work when bloom is off.